### PR TITLE
Return Column Comment

### DIFF
--- a/src/main/java/com/dnastack/ga4gh/search/tables/ColumnSchema.java
+++ b/src/main/java/com/dnastack/ga4gh/search/tables/ColumnSchema.java
@@ -22,4 +22,7 @@ public class ColumnSchema {
 
     @JsonProperty("x-ga4gh-position")
     private int position;
+
+    @JsonProperty("$comment")
+    private String comment;
 }


### PR DESCRIPTION
Example Response from `http://localhost:8089/table/search_drs.org_ga4gh_drs.json_objects/info`:
```json
{
    "name": "search_drs.org_ga4gh_drs.json_objects",
    "description": null,
    "data_model": {
        "$id": "http://localhost:8089/table/search_drs.org_ga4gh_drs.json_objects/info",
        "description": "Automatically generated schema.",
        "$schema": "http://json-schema.org/draft-07/schema#",
        "properties": {
            "id": {
                "type": "string",
                "format": "varchar",
                "x-ga4gh-position": 0,
                "$comment": "An identifier unique to this Data Object"
            },
            "json": {
                "type": "string",
                "format": "varchar",
                "x-ga4gh-position": 1,
                "$comment": "Data Object JSON"
            }
        }
    }
}
```
Notes
1. Right now I'm filtering out blank comments from the comment column in the response, so we have `$comment: null` rather than `$comment: ""`. Let me know if this is not desirable behaviour.
2. Comments are currently only present in responses from `/table/{tableName}/info` or `/table/{tableName}/data`. I wasn't sure the intent of this story was to only have comments present in only the `info` endpoint, or in all metadata from any endpoint in the search adapter. In the later case, this seems difficult to me. For example in the case of the `/search/**` endpoint for next page urls, there doesn't seem to be a table name immediately available, which we'd need to issue the describe table query.